### PR TITLE
added package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "cordova-plugin-discovery",
-  "version": "0.2.0"
+  "version": "1.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "cordova-plugin-discovery",
+  "version": "0.2.0"
+}


### PR DESCRIPTION
package will not install correctly without a _package.json_ file.

Error when trying to install the package (npm v5.4.2):
`ENOENT: no such file or directory, open '~/.npm/_cacache/tmp/git-clone-8a7f64ed/package.json'
`
this commit fixes the problem.